### PR TITLE
This should make actual lessons sortable

### DIFF
--- a/app/views/instructor/courses/show.html.erb
+++ b/app/views/instructor/courses/show.html.erb
@@ -10,16 +10,20 @@
     <%= link_to 'Add a new section...', new_instructor_course_section_path(current_course), class: 'btn btn-primary btn-lg' %>
   </div>
 
-  <ul id="lessons">
+  <ul>
     <% current_course.sections.each do |section| %>
       <li>
         <%= section.title %>
         <%= link_to 'New Lesson', new_instructor_section_lesson_path(section), class: 'float-right btn btn-primary btn-sm' %>
-        <% section.lessons.rank(:row_order).each do |lesson| %>
-          <b><%= lesson.title %></b>
-          -
-          <%= lesson.subtitle %>
-        <% end %>
+        <ul id="lessons">
+          <% section.lessons.rank(:row_order).each do |lesson| %>
+            <li>
+              <b><%= lesson.title %></b>
+              -
+              <%= lesson.subtitle %>
+            </li>
+          <% end %>
+        </ul>
         <br class="clr" />
       </li>
     <% end %>


### PR DESCRIPTION
The other commit was to make sections draggable, but this now makes LESSONS draggable. We were on the right track last night, but I think we mixed up the location of one of the `<ul>`s

![jake](https://user-images.githubusercontent.com/3905259/51955380-b74f9200-2411-11e9-9042-d72c16e40c1e.gif)
